### PR TITLE
Tic Tac Toe support

### DIFF
--- a/Lib/Lib.csproj
+++ b/Lib/Lib.csproj
@@ -123,6 +123,7 @@
     <Compile Include="ModuleTranslators\ModuleTranslator.cs" />
     <Compile Include="ModuleTranslators\OnlyStartModuleTranslator.cs" />
     <Compile Include="ModuleTranslators\MurderTranslator.cs" />
+    <Compile Include="ModuleTranslators\TicTacToeTranslator.cs" />
     <Compile Include="Patch.cs" />
     <Compile Include="ReflectionHelper.cs" />
     <Compile Include="Settings.cs" />

--- a/Lib/ModuleTranslators/TicTacToeTranslator.cs
+++ b/Lib/ModuleTranslators/TicTacToeTranslator.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections;
+using UnityEngine;
+using HarmonyLib;
+using System.Reflection;
+using System.Linq;
+
+namespace TranslationService.ModuleTranslators
+{
+    class TicTacToeTranslator : ModuleTranslator
+    {
+        public TicTacToeTranslator()
+        {
+        }
+
+        private static Magnifier displayMagnifier(string langCode) => langCode == "ja" ? new Magnifier.VectorMagnifier(1f, 0.026812f) : new Magnifier.VectorMagnifier(1f, 0.017875f);
+
+        public override void StartTranslation(KMBombModule module, Translator translator)
+        {
+            TicTacToeTranslator.translator = translator;
+        }
+
+        public override void AwakeTranslation(KMBombModule module, Translator translator)
+        {
+            // p = "PASS" ; u = "UP NEXT:"
+            var texts = module.GetComponentsInChildren<TextMesh>().Where(text => text.text == "u" || text.text == "p").ToArray();
+            Font font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+            translator.SetTranslationToMeshes(texts, module, displayMagnifier(translator.langCode), font, true);
+        }
+
+        public static Translator translator = null;
+    }
+}

--- a/Lib/SupportAssign.cs
+++ b/Lib/SupportAssign.cs
@@ -71,7 +71,8 @@ namespace TranslationService
         public readonly static Dictionary<string, Func<Harmony, ModuleTranslator>> CustomDictionary = new Dictionary<string, Func<Harmony, ModuleTranslator>>() {
             {"Orientation Cube", harmony => new OnlyStartModuleTranslator(new OrientationCubeMagnifier()) },
             {"Adventure Game", harmony => new AdventureGameTranslator(harmony) },
-            {"Murder", harmony => new MurderTranslator(harmony) }
+            {"Murder", harmony => new MurderTranslator(harmony) },
+            {"Tic Tac Toe", harmony => new TicTacToeTranslator() }
         };
     }
 }

--- a/Lib/Translator.cs
+++ b/Lib/Translator.cs
@@ -42,7 +42,7 @@ namespace TranslationService
             return _dict ??= loader.GetTranslation(langCode);
         }
 
-        public string? GetTranslation(string from, string moduleName)
+        public string? GetTranslation(string from, string moduleName, bool allCaps = false)
         {
             if (LoadTranslations() is not Dictionary<string, string> dict) return null;
             var trimmed = from.Trim();
@@ -50,31 +50,31 @@ namespace TranslationService
             var upper = trimmed.ToUpperInvariant();
             if (dict.TryGetValue(moduleName + ":" +lower, out string to) || dict.TryGetValue(lower, out to))
             {
-                if (trimmed == upper) return to.ToUpperInvariant();
+                if (allCaps || trimmed == upper) return to.ToUpperInvariant();
                 else if (trimmed[0] == upper[0]) return to.Substring(0, 1).ToUpperInvariant() + to.Substring(1).ToLowerInvariant();
                 else return to.ToLowerInvariant();
             }
             return null;
         }
 
-        public void SetTranslationToMeshes(TextMesh[] textmeshes, KMBombModule module)
+        public void SetTranslationToMeshes(TextMesh[] textmeshes, KMBombModule module, Font? fontOverride = null, bool allCaps = false)
         {
-            SetTranslationToMeshes(textmeshes, module, Magnifier.Default);
+            SetTranslationToMeshes(textmeshes, module, Magnifier.Default, fontOverride, allCaps);
         }
-        public void SetTranslationToMeshes(TextMesh[] textmeshes, KMBombModule module, Magnifier magnifier)
+        public void SetTranslationToMeshes(TextMesh[] textmeshes, KMBombModule module, Magnifier magnifier, Font? fontOverride = null, bool allCaps = false)
         {
             foreach (var textMesh in textmeshes)
             {
-                SetTranslationToMesh(textMesh, module, magnifier);
+                SetTranslationToMesh(textMesh, module, magnifier, fontOverride, allCaps);
             }
         }
-        public void SetTranslationToMesh(TextMesh textmesh, KMBombModule module, Magnifier magnifier)
+        public void SetTranslationToMesh(TextMesh textmesh, KMBombModule module, Magnifier magnifier, Font? fontOverride = null, bool allCaps = false)
         {
             MeshRenderer renderer = textmesh.GetComponent<MeshRenderer>();
             Transform transform = textmesh.GetComponent<Transform>();
             string moduleName = module.ModuleDisplayName;
 
-            if (GetTranslation(textmesh.text, moduleName) is string translated)
+            if (GetTranslation(textmesh.text, moduleName, allCaps) is string translated)
             {
 
                 // Changing alignment to center
@@ -86,7 +86,12 @@ namespace TranslationService
                 Vector2 beforeSize = renderer.bounds.size;
 
                 string beforeTranslation = textmesh.text;
-                if (font != null && fontMaterial != null)
+                if (fontOverride != null)
+                {
+                    textmesh.font = fontOverride;
+                    renderer.material = fontOverride.material;
+                }
+                else if (font != null && fontMaterial != null)
                 {
                     textmesh.font = font;
                     renderer.material = fontMaterial;


### PR DESCRIPTION
Known issue: the text is not centered vertically.

Here I just get the default Arial font from unity. Should we instead add a default font in the Translator dictionary?
By the way I don't know if this works on Mac/Linux.
